### PR TITLE
Use theme brand in header banner

### DIFF
--- a/src/components/personas/HeaderBanner.tsx
+++ b/src/components/personas/HeaderBanner.tsx
@@ -1,10 +1,17 @@
+"use client";
+
 import React from "react";
+import { useTheme } from "@/contexts/ThemeContext";
 
 const HeaderBanner: React.FC = () => {
+  const { theme } = useTheme();
+
   return (
     <header className="bg-[#003C2D] text-white p-6 shadow-md">
       <div className="max-w-7xl mx-auto">
-        <h1 className="text-2xl font-bold">Korn Ferry Global Personas</h1>
+        <h1 className="text-2xl font-bold">
+          {theme?.brandName || "Korn Ferry Personas"}
+        </h1>
       </div>
     </header>
   );

--- a/src/components/personas/__tests__/HeaderBanner.test.tsx
+++ b/src/components/personas/__tests__/HeaderBanner.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import HeaderBanner from "../HeaderBanner";
+
+jest.mock("@/contexts/ThemeContext", () => ({
+  useTheme: () => ({
+    theme: { brandName: "Test Brand" },
+    isLoading: false,
+  }),
+}));
+
+describe("HeaderBanner", () => {
+  it("renders the brand name from theme", () => {
+    render(<HeaderBanner />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Test Brand"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- show theme brand name in the personas header
- test brand name rendering in `HeaderBanner`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685111481f48832496beb47b39c50735