### PR TITLE
Add brand CRUD endpoints with UI hooks

### DIFF
--- a/src/app/api/__tests__/brand-crud.test.ts
+++ b/src/app/api/__tests__/brand-crud.test.ts
@@ -1,0 +1,60 @@
+/* @jest-environment node */
+import fs from 'fs/promises';
+import path from 'path';
+import { NextRequest } from 'next/server';
+import { DELETE as deleteBrand } from '../brand/delete/route';
+import { POST as cloneBrand } from '../brand/clone/route';
+import { POST as renameBrand } from '../brand/rename/route';
+
+describe('Brand CRUD API', () => {
+  const brandsRoot = path.join(process.cwd(), 'public', 'brands');
+  const backupsRoot = path.join(process.cwd(), 'backups', 'brands');
+
+  const setupBrand = async (slug: string) => {
+    const dir = path.join(brandsRoot, slug);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'brand.config.json'), JSON.stringify({ brandName: slug }, null, 2));
+  };
+
+  const cleanDir = async (p: string) => {
+    await fs.rm(p, { recursive: true, force: true });
+  };
+
+  afterEach(async () => {
+    await cleanDir(path.join(brandsRoot, 'test-brand'));
+    await cleanDir(path.join(brandsRoot, 'cloned-brand'));
+    await cleanDir(path.join(brandsRoot, 'renamed-brand'));
+    // remove backups
+    await fs.readdir(backupsRoot).then(files => Promise.all(files.map(f => cleanDir(path.join(backupsRoot, f))))).catch(() => {});
+  });
+
+  it('clones a brand directory', async () => {
+    await setupBrand('test-brand');
+    const req = new NextRequest(new Request('http://localhost/api/brand/clone', { method: 'POST', body: JSON.stringify({ source: 'test-brand', newName: 'Cloned Brand' }) }));
+    const res = await cloneBrand(req);
+    expect(res.status).toBe(200);
+    const targetDir = path.join(brandsRoot, 'cloned-brand');
+    const stat = await fs.stat(targetDir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('renames a brand directory', async () => {
+    await setupBrand('test-brand');
+    const req = new NextRequest(new Request('http://localhost/api/brand/rename', { method: 'POST', body: JSON.stringify({ oldName: 'test-brand', newName: 'Renamed Brand' }) }));
+    const res = await renameBrand(req);
+    expect(res.status).toBe(200);
+    await expect(fs.access(path.join(brandsRoot, 'test-brand'))).rejects.toBeDefined();
+    const stat = await fs.stat(path.join(brandsRoot, 'renamed-brand'));
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('soft deletes a brand directory', async () => {
+    await setupBrand('test-brand');
+    const req = new NextRequest(new Request('http://localhost/api/brand/delete?name=test-brand', { method: 'DELETE' }));
+    const res = await deleteBrand(req);
+    expect(res.status).toBe(200);
+    await expect(fs.access(path.join(brandsRoot, 'test-brand'))).rejects.toBeDefined();
+    const backups = await fs.readdir(backupsRoot);
+    expect(backups.some(name => name.startsWith('test-brand_'))).toBe(true);
+  });
+});

--- a/src/app/api/brand/clone/route.ts
+++ b/src/app/api/brand/clone/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+const BRANDS_ROOT = path.join(process.cwd(), "public", "brands");
+
+function sanitize(name: string): string | null {
+  const normalized = path.normalize(name).replace(/^(\.\.[\/\\])+/,'');
+  if (normalized.includes('/') || normalized.includes('\\')) return null;
+  return normalized;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { source, newName } = await request.json();
+    if (!source || !newName) {
+      return NextResponse.json({ error: 'Missing required fields.' }, { status: 400 });
+    }
+
+    const sourceSlug = sanitize(source);
+    const targetSlug = sanitize(newName.trim().toLowerCase().replace(/\s+/g, '-'));
+    if (!sourceSlug || !targetSlug) {
+      return NextResponse.json({ error: 'Invalid brand name provided.' }, { status: 400 });
+    }
+
+    const sourceDir = path.join(BRANDS_ROOT, sourceSlug);
+    const targetDir = path.join(BRANDS_ROOT, targetSlug);
+
+    await fs.access(sourceDir).catch(() => { throw new Error('SOURCE_NOT_FOUND'); });
+    const targetExists = await fs.access(targetDir).then(() => true).catch(() => false);
+    if (targetExists) {
+      return NextResponse.json({ error: 'Target brand already exists.' }, { status: 409 });
+    }
+
+    await fs.cp(sourceDir, targetDir, { recursive: true });
+
+    const configPath = path.join(targetDir, 'brand.config.json');
+    try {
+      const data = await fs.readFile(configPath, 'utf8');
+      const config = JSON.parse(data);
+      config.brandName = newName.trim();
+      await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf8');
+    } catch { /* ignore if config missing */ }
+
+    return NextResponse.json({ success: true, brand: targetSlug });
+  } catch (err: any) {
+    if (err.message === 'SOURCE_NOT_FOUND') {
+      return NextResponse.json({ error: 'Source brand not found.' }, { status: 404 });
+    }
+    console.error('Error cloning brand:', err);
+    return NextResponse.json({ error: 'Failed to clone brand.' }, { status: 500 });
+  }
+}

--- a/src/app/api/brand/delete/route.ts
+++ b/src/app/api/brand/delete/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+const BRANDS_ROOT = path.join(process.cwd(), "public", "brands");
+const BACKUP_ROOT = path.join(process.cwd(), "backups", "brands");
+
+function sanitize(name: string): string | null {
+  const normalized = path.normalize(name).replace(/^(\.\.[\/\\])+/,'');
+  if (normalized.includes('/') || normalized.includes('\\')) return null;
+  return normalized;
+}
+
+export async function DELETE(request: NextRequest) {
+  const brandName = request.nextUrl.searchParams.get('name');
+  if (!brandName) {
+    return NextResponse.json({ error: 'Brand name query parameter is required.' }, { status: 400 });
+  }
+
+  const slug = sanitize(brandName);
+  if (!slug) {
+    return NextResponse.json({ error: 'Invalid brand name provided.' }, { status: 400 });
+  }
+
+  const brandDir = path.join(BRANDS_ROOT, slug);
+  try {
+    await fs.access(brandDir);
+  } catch {
+    return NextResponse.json({ error: `Brand '${slug}' not found.` }, { status: 404 });
+  }
+
+  await fs.mkdir(BACKUP_ROOT, { recursive: true });
+  const backupDir = path.join(BACKUP_ROOT, `${slug}_${Date.now()}`);
+  await fs.rename(brandDir, backupDir);
+
+  return NextResponse.json({ success: true, backup: path.relative(process.cwd(), backupDir) });
+}

--- a/src/app/api/brand/rename/route.ts
+++ b/src/app/api/brand/rename/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+const BRANDS_ROOT = path.join(process.cwd(), "public", "brands");
+
+function sanitize(name: string): string | null {
+  const normalized = path.normalize(name).replace(/^(\.\.[\/\\])+/,'');
+  if (normalized.includes('/') || normalized.includes('\\')) return null;
+  return normalized;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { oldName, newName } = await request.json();
+    if (!oldName || !newName) {
+      return NextResponse.json({ error: 'Missing required fields.' }, { status: 400 });
+    }
+
+    const oldSlug = sanitize(oldName);
+    const newSlug = sanitize(newName.trim().toLowerCase().replace(/\s+/g, '-'));
+    if (!oldSlug || !newSlug) {
+      return NextResponse.json({ error: 'Invalid brand name provided.' }, { status: 400 });
+    }
+
+    const oldDir = path.join(BRANDS_ROOT, oldSlug);
+    const newDir = path.join(BRANDS_ROOT, newSlug);
+
+    await fs.access(oldDir).catch(() => { throw new Error('OLD_NOT_FOUND'); });
+    const exists = await fs.access(newDir).then(() => true).catch(() => false);
+    if (exists) {
+      return NextResponse.json({ error: 'Target brand already exists.' }, { status: 409 });
+    }
+
+    await fs.rename(oldDir, newDir);
+    const configPath = path.join(newDir, 'brand.config.json');
+    try {
+      const data = await fs.readFile(configPath, 'utf8');
+      const config = JSON.parse(data);
+      config.brandName = newName.trim();
+      await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf8');
+    } catch { /* ignore if config missing */ }
+
+    return NextResponse.json({ success: true, brand: newSlug });
+  } catch (err: any) {
+    if (err.message === 'OLD_NOT_FOUND') {
+      return NextResponse.json({ error: 'Brand not found.' }, { status: 404 });
+    }
+    console.error('Error renaming brand:', err);
+    return NextResponse.json({ error: 'Failed to rename brand.' }, { status: 500 });
+  }
+}

--- a/src/components/admin/brand-setup/BrandSetupWizard.tsx
+++ b/src/components/admin/brand-setup/BrandSetupWizard.tsx
@@ -162,6 +162,82 @@ const BrandSetupWizard = () => {
     }
   };
 
+  const handleDeleteBrand = async () => {
+    if (!selectedBrand) return;
+    if (!confirm(`Delete brand "${selectedBrand}"? A backup will be created.`)) return;
+    setIsSaving(true);
+    try {
+      const res = await fetch(`/api/brand/delete?name=${selectedBrand}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to delete brand.');
+      const updated = brands.filter(b => b !== selectedBrand);
+      setBrands(updated);
+      setSelectedBrand(updated[0] || '');
+      alert(`Brand "${selectedBrand}" deleted.`);
+    } catch (err: any) {
+      console.error(err);
+      alert(err.message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCloneBrand = async () => {
+    if (!selectedBrand) return;
+    const newName = prompt('Enter name for cloned brand:');
+    if (!newName) return;
+    const sanitized = newName.trim().toLowerCase().replace(/\s+/g, '-');
+    if (brands.includes(sanitized)) {
+      alert(`Brand "${sanitized}" already exists.`);
+      return;
+    }
+    if (!confirm(`Clone "${selectedBrand}" to "${newName}"?`)) return;
+    setIsSaving(true);
+    try {
+      const res = await fetch('/api/brand/clone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source: selectedBrand, newName }),
+      });
+      if (!res.ok) throw new Error('Failed to clone brand.');
+      setBrands([...brands, sanitized].sort());
+      setSelectedBrand(sanitized);
+    } catch (err: any) {
+      console.error(err);
+      alert(err.message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleRenameBrand = async () => {
+    if (!selectedBrand) return;
+    const newName = prompt('Enter new name for brand:');
+    if (!newName) return;
+    const sanitized = newName.trim().toLowerCase().replace(/\s+/g, '-');
+    if (brands.includes(sanitized)) {
+      alert(`Brand "${sanitized}" already exists.`);
+      return;
+    }
+    if (!confirm(`Rename "${selectedBrand}" to "${newName}"?`)) return;
+    setIsSaving(true);
+    try {
+      const res = await fetch('/api/brand/rename', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ oldName: selectedBrand, newName }),
+      });
+      if (!res.ok) throw new Error('Failed to rename brand.');
+      const updated = brands.map(b => (b === selectedBrand ? sanitized : b)).sort();
+      setBrands(updated);
+      setSelectedBrand(sanitized);
+    } catch (err: any) {
+      console.error(err);
+      alert(err.message);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   const handleSave = async () => {
     if (!settings || !selectedBrand) return;
     setIsSaving(true);
@@ -269,7 +345,30 @@ const BrandSetupWizard = () => {
           <div className="lg:col-span-1">
             <LivePreview settings={settings} />
           </div>
-          <div className="lg:col-span-3 flex justify-end mt-4">
+          <div className="lg:col-span-3 flex justify-between mt-4 flex-wrap gap-2">
+            <div className="space-x-2">
+              <button
+                onClick={handleCloneBrand}
+                disabled={isSaving}
+                className="px-4 py-2 bg-purple-600 text-white font-semibold rounded-lg shadow-md hover:bg-purple-700 disabled:bg-gray-400 transition-all"
+              >
+                Clone
+              </button>
+              <button
+                onClick={handleRenameBrand}
+                disabled={isSaving}
+                className="px-4 py-2 bg-yellow-600 text-white font-semibold rounded-lg shadow-md hover:bg-yellow-700 disabled:bg-gray-400 transition-all"
+              >
+                Rename
+              </button>
+              <button
+                onClick={handleDeleteBrand}
+                disabled={isSaving}
+                className="px-4 py-2 bg-red-600 text-white font-semibold rounded-lg shadow-md hover:bg-red-700 disabled:bg-gray-400 transition-all"
+              >
+                Delete
+              </button>
+            </div>
             <button
               onClick={handleSave}
               disabled={isSaving}


### PR DESCRIPTION
## Summary
- add DELETE, CLONE and RENAME API endpoints for brands
- expose clone/rename/delete controls in the BrandSetupWizard
- keep deleted brands as backups
- test new brand CRUD endpoints

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6851156f29d08324adedcbdf9fc6d2e0